### PR TITLE
Fix install in SimpleJsiModule

### DIFF
--- a/android/src/main/java/com/reactnativesimplejsi/SimpleJsiModule.java
+++ b/android/src/main/java/com/reactnativesimplejsi/SimpleJsiModule.java
@@ -37,14 +37,12 @@ public class SimpleJsiModule extends ReactContextBaseJavaModule {
     System.loadLibrary("cpp");
     JavaScriptContextHolder jsContext = getReactApplicationContext().getJavaScriptContextHolder();
 
-    if (jsContext != 0) {
+    if (jsContext.get() != 0) {
       this.nativeInstall(
         jsContext.get()
       );
-      return true;
     } else {
       Log.e("SimpleJsiModule", "JSI Runtime is not available in debug mode");
-      return false;
     }
 
   }

--- a/android/src/main/java/com/reactnativesimplejsi/SimpleJsiModule.java
+++ b/android/src/main/java/com/reactnativesimplejsi/SimpleJsiModule.java
@@ -31,9 +31,8 @@ public class SimpleJsiModule extends ReactContextBaseJavaModule {
 
 // Installing JSI Bindings as done by
 // https://github.com/mrousavy/react-native-mmkv
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public void install() {
-
+   @ReactMethod(isBlockingSynchronousMethod = true)
+  public boolean install() {
     System.loadLibrary("cpp");
     JavaScriptContextHolder jsContext = getReactApplicationContext().getJavaScriptContextHolder();
 
@@ -41,8 +40,10 @@ public class SimpleJsiModule extends ReactContextBaseJavaModule {
       this.nativeInstall(
         jsContext.get()
       );
+      return true;
     } else {
       Log.e("SimpleJsiModule", "JSI Runtime is not available in debug mode");
+      return false;
     }
 
   }


### PR DESCRIPTION
I fixed 2 errors that block building the android

```
Operator '!=' cannot be applied to 'com.facebook.react.bridge.JavaScriptContextHolder', 'int'
Cannot return a value from a method with void result type
```